### PR TITLE
update/unnecessary looping while product archive page doesn't have any product

### DIFF
--- a/woocommerce/archive-product.php
+++ b/woocommerce/archive-product.php
@@ -40,6 +40,7 @@ get_header(); ?>
     </header>
 
     <?php
+    if ( woocommerce_product_loop() ) {
     /**
      * woocommerce_before_shop_loop hook
      *
@@ -48,7 +49,6 @@ get_header(); ?>
      */
     do_action( 'woocommerce_before_shop_loop' );
 
-    if ( woocommerce_product_loop() ) {
         ?>
 
         <?php

--- a/woocommerce/archive-product.php
+++ b/woocommerce/archive-product.php
@@ -13,88 +13,89 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header(); ?>
 
-    <?php
-    /**
-     * Hook: woocommerce_before_main_content.
-     *
-     * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
-     * @hooked woocommerce_breadcrumb - 20
-     * @hooked WC_Structured_Data::generate_website_data() - 30
-     */
-    do_action( 'woocommerce_before_main_content' ); ?>
+	<?php
+	/**
+	 * Hook: woocommerce_before_main_content.
+	 *
+	 * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
+	 * @hooked woocommerce_breadcrumb - 20
+	 * @hooked WC_Structured_Data::generate_website_data() - 30
+	 */
+	do_action( 'woocommerce_before_main_content' );
+	?>
 
-    <header class="woocommerce-products-header">
-        <?php if ( apply_filters( 'woocommerce_show_page_title', true ) ) : ?>
-            <h1 class="woocommerce-products-header__title page-title"><?php woocommerce_page_title(); ?></h1>
-        <?php endif; ?>
+	<header class="woocommerce-products-header">
+		<?php if ( apply_filters( 'woocommerce_show_page_title', true ) ) : ?>
+			<h1 class="woocommerce-products-header__title page-title"><?php woocommerce_page_title(); ?></h1>
+		<?php endif; ?>
 
-        <?php
-        /**
-         * Hook: woocommerce_archive_description.
-         *
-         * @hooked woocommerce_taxonomy_archive_description - 10
-         * @hooked woocommerce_product_archive_description - 10
-         */
-        do_action( 'woocommerce_archive_description' );
-        ?>
-    </header>
+		<?php
+		/**
+		 * Hook: woocommerce_archive_description.
+		 *
+		 * @hooked woocommerce_taxonomy_archive_description - 10
+		 * @hooked woocommerce_product_archive_description - 10
+		 */
+		do_action( 'woocommerce_archive_description' );
+		?>
+	</header>
 
-    <?php
-    if ( woocommerce_product_loop() ) {
-    /**
-     * woocommerce_before_shop_loop hook
-     *
-     * @hooked woocommerce_result_count - 20
-     * @hooked woocommerce_catalog_ordering - 30
-     */
-    do_action( 'woocommerce_before_shop_loop' );
+	<?php
+	if ( woocommerce_product_loop() ) {
+		/**
+		 * woocommerce_before_shop_loop hook
+		 *
+		 * @hooked woocommerce_result_count - 20
+		 * @hooked woocommerce_catalog_ordering - 30
+		 */
+		do_action( 'woocommerce_before_shop_loop' );
 
-        ?>
+		?>
 
-        <?php
-        woocommerce_product_loop_start();
+		<?php
+		woocommerce_product_loop_start();
 
-        if ( wc_get_loop_prop( 'total' ) ) {
-            while ( have_posts() ) {
-                the_post();
+		if ( wc_get_loop_prop( 'total' ) ) {
+			while ( have_posts() ) {
+				the_post();
 
-                /**
-                 * Hook: woocommerce_shop_loop.
-                 *
-                 * @hooked WC_Structured_Data::generate_product_data() - 10
-                 */
-                do_action( 'woocommerce_shop_loop' );
+				/**
+				 * Hook: woocommerce_shop_loop.
+				 *
+				 * @hooked WC_Structured_Data::generate_product_data() - 10
+				 */
+				do_action( 'woocommerce_shop_loop' );
 
-                wc_get_template_part( 'content', 'product' );
-            }
-        }
+				wc_get_template_part( 'content', 'product' );
+			}
+		}
 
-        woocommerce_product_loop_end();
+		woocommerce_product_loop_end();
 
-        /**
-         * Hook: woocommerce_after_shop_loop.
-         *
-         * @hooked woocommerce_pagination - 10
-         */
-        do_action( 'woocommerce_after_shop_loop' );
+		/**
+		 * Hook: woocommerce_after_shop_loop.
+		 *
+		 * @hooked woocommerce_pagination - 10
+		 */
+		do_action( 'woocommerce_after_shop_loop' );
 
-    } else {
-        /**
-         * Hook: woocommerce_no_products_found.
-         *
-         * @hooked wc_no_products_found - 10
-         */
-        do_action( 'woocommerce_no_products_found' );
-    }
+	} else {
+		/**
+		 * Hook: woocommerce_no_products_found.
+		 *
+		 * @hooked wc_no_products_found - 10
+		 */
+		do_action( 'woocommerce_no_products_found' );
+	}
 
-    /**
-     * Hook: woocommerce_after_main_content.
-     *
-     * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
-     */
-    do_action( 'woocommerce_after_main_content' );
+	/**
+	 * Hook: woocommerce_after_main_content.
+	 *
+	 * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
+	 */
+	do_action( 'woocommerce_after_main_content' );
 
-    ?>
+	?>
 
 	<?php
 	/**
@@ -106,4 +107,4 @@ get_header(); ?>
 
 	 dokani_construct_sidebars();
 
-get_footer();
+	get_footer();


### PR DESCRIPTION
Fixed unnecessary looping while the product archive page doesn't have any product. By replacing the `woocommerce_product_loop()` place.
Before - https://snipboard.io/9By86v.jpg
Now - https://snipboard.io/RlmXNu.jpg