### PR TITLE
Fix: Store location widget not show default location if not set location from vendor store settings.

### DIFF
--- a/dokan/widgets/store-map.php
+++ b/dokan/widgets/store-map.php
@@ -17,8 +17,8 @@
             jQuery(function($) {
                 <?php
                 $locations = explode( ',', $map_location );
-                $def_lat = isset( $locations[0] ) ? $locations[0] : 90.40714300000002;
-                $def_long = isset( $locations[1] ) ? $locations[1] : 23.709921;
+                $def_lat = ! empty( $locations[0] ) ? $locations[0] : 90.40714300000002;
+                $def_long = ! empty( $locations[1] ) ? $locations[1] : 23.709921;
                 ?>
 
                 var def_longval = <?php echo esc_html( $def_long ); ?>;


### PR DESCRIPTION
If a vendor is not set location from [store settings ](https://prnt.sc/26dkwkj) (Left blank). The map doesn't show the default location.

Suggestion for QA: 
1. First setup Google Maps API key from Dokan admin dashboard > settings > [appearance tab ](https://prnt.sc/26dlajn)
2. Set location from the vendor [store settings](https://prnt.sc/26dl9c7)
3. Check location is showing on the [vendor store page ](https://prnt.sc/26dla2u) sidebar