### PR TITLE
fix: Mini cart loading issue after WooCommerce updated to v7.8.0

### DIFF
--- a/inc/general.php
+++ b/inc/general.php
@@ -55,6 +55,8 @@ if ( ! function_exists( 'dokani_scripts' ) ) {
 		wp_enqueue_script( 'dokani-tooltip', $dir_uri . "/assets/js/tooltips.min.js", array( 'jquery' ) );
 		wp_enqueue_script( 'dokani-script', $dir_uri . "/assets/js/script.js", array( 'jquery' ), DOKANI_VERSION, true );
 
+		wp_enqueue_script( 'wc-cart-fragments' ); // Enqueue cart fragment script for loaded mini cart preview on `dokani` theme.
+
 		if ( 'click' == $dokani_settings[ 'nav_dropdown_type' ] || 'click-arrow' == $dokani_settings[ 'nav_dropdown_type' ] ) {
 			wp_enqueue_script( 'dokani-dropdown-click', $dir_uri . "/assets/js/dropdown-click{$suffix}.js", array( 'dokani-menu' ), DOKANI_VERSION, true );
 		}


### PR DESCRIPTION
### Fix: Mini cart loading issue after WooCommerce updated to v7.8.0.

As per the [Woocommerce explanation](https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/), they have removed wc-cart-fragments to increase the performance. Please see https://stackoverflow.com/a/76505287/2286634 for more details.

**Issue:** [#42](https://github.com/weDevsOfficial/dokan-theme/issues/42)

**After Update:**

<img width="713" alt="image" src="https://github.com/weDevsOfficial/dokani/assets/90011088/714b2628-e833-4cb1-84fd-9e21151027be">

**Before Update:**

<img width="813" alt="image" src="https://github.com/weDevsOfficial/dokani/assets/90011088/dee9b637-ae0f-4e9a-97b6-03f7e46634c6">
